### PR TITLE
Corrected no ETH required clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,4 @@ Note: Proposal incentive reward amounts are subject to change in the event of ab
 4. Press `Access`
 5. Select function -> `vote`
 6. In the `Candidate` field put the number of your selection, which is shown as the `ID:` on the voting interface
-7. Send the transaction. **No Ether or DNT is required to send**. The recommended gas limit is 100000   
-
+7. Send the transaction. **No DNT is required to send**, but please ensure you have a very small amount of ETH (<0.001) to cover for the gas fee. The recommended gas limit is 100000.


### PR DESCRIPTION
A lot of voters were confused about not being able to vote because there was no ETH in their wallet, they had been pointing to the clause which states no ETH is required for voting. But we have to account for gas fee, and a small amount of ETH is required with the current voting system to be able to send the transaction that contains the vote.